### PR TITLE
Fix a bug with parameter order

### DIFF
--- a/src/porkbun_api.py
+++ b/src/porkbun_api.py
@@ -114,4 +114,4 @@ def ddns_update(domain:str, ip:str = "", subdomain:str = "", apikey:str = "", se
         ipaddr = ip
     else:
         ipaddr = ping(apikey = apikey, secretapikey = secretapikey, ipv4only = False if not ipv4only else True)
-    update(domain, "A" if ipv4only or ":" not in ip else "AAAA", subdomain, ipaddr, apikey = apikey, secretapikey = secretapikey)
+    update(domain, "A" if ipv4only or ":" not in ip else "AAAA", subdomain = subdomain, content = ipaddr, apikey = apikey, secretapikey = secretapikey)


### PR DESCRIPTION
When calling update() inside ddns_update(), the parameters subdomain and content are in reverse order, which generates an invalid URL.
Unfortunately, Porkbun does not fail the request. It just ignores it and returns success. Therefore, you only see the problem when a real DDNS update is needed.
